### PR TITLE
use the original name for lazy-regex-proc_macros, fix #5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ readme = "README.md"
 once_cell = "1.7"
 regex = "1.5"
 
-[dependencies.proc_macros]
-package = "lazy-regex-proc_macros"
+[dependencies.lazy-regex-proc_macros]
 path = "src/proc_macros"
 version = "2.0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ It's checked at compile time to ensure you have the right number of capturing gr
 
 pub use {
     once_cell,
-    proc_macros::{
+    lazy_regex_proc_macros::{
         regex,
         regex_captures,
         regex_find,


### PR DESCRIPTION
I don't know why but this fixes #5.