### PR TITLE
Re-export all necessary types from the regex crate

### DIFF
--- a/examples/regexes/src/main.rs
+++ b/examples/regexes/src/main.rs
@@ -1,11 +1,8 @@
-use {
-    lazy_regex::*,
-};
+use lazy_regex::*;
 
 pub static SHARED: Lazy<Regex> = lazy_regex!("^test$");
 
 fn example_builds() {
-
     // build a simple regex
     let r = regex!("sa+$");
     assert_eq!(r.is_match("Saa"), false);
@@ -24,7 +21,6 @@ fn example_builds() {
 
     // this line wouldn't compile:
     // let r = regex!("(unclosed");
-
 }
 
 fn example_is_match() {
@@ -39,9 +35,10 @@ fn example_using_shared_static() {
 
 fn example_captures() {
     let (whole, name, version) = regex_captures!(
-        r#"(\w+)-([0-9.]+)"#, // a literal regex
+        r#"(\w+)-([0-9.]+)"#,      // a literal regex
         "This is lazy_regex-2.0!", // any expression
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(whole, "lazy_regex-2.0");
     assert_eq!(name, "lazy_regex");
     assert_eq!(version, "2.0");
@@ -69,14 +66,13 @@ fn examples_replace_all() {
         |_, a: &str, b: &str| {
             let a: u64 = a.parse().unwrap();
             let b: u64 = b.parse().unwrap();
-            (a+b).to_string()
+            (a + b).to_string()
         },
     );
     assert_eq!(text, "A = 8 and B=31");
 }
 
 fn main() {
-
     // the regular expressions will be built only once
     for _ in 0..10 {
         example_builds();
@@ -89,5 +85,4 @@ fn main() {
         example_using_shared_static();
         examples_replace_all();
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,15 +139,9 @@ doc: [lazy_regex!]
 */
 
 pub use {
-    once_cell::sync::Lazy,
     lazy_regex_proc_macros::{
-        lazy_regex,
-        regex,
-        regex_captures,
-        regex_find,
-        regex_is_match,
-        regex_replace_all,
+        lazy_regex, regex, regex_captures, regex_find, regex_is_match, regex_replace_all,
     },
+    once_cell::sync::Lazy,
     regex::{Captures, Regex, RegexBuilder},
 };
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,6 @@ pub use {
         regex_is_match,
         regex_replace_all,
     },
-    regex::Regex,
+    regex::{Captures, Regex, RegexBuilder},
 };
 

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -47,9 +47,9 @@ impl From<LitStr> for RegexCode {
         let regex = regex::Regex::new(&regex_string).unwrap();
 
         let build = quote! {{
-            Lazy::new(|| {
+            lazy_regex::Lazy::new(|| {
                 //println!("compiling regex {:?}", #regex_string);
-                let mut builder = regex::RegexBuilder::new(#regex_string);
+                let mut builder = lazy_regex::RegexBuilder::new(#regex_string);
                 builder.case_insensitive(#case_insensitive);
                 builder.multi_line(#multi_line);
                 builder.dot_matches_new_line(#dot_matches_new_line);
@@ -74,8 +74,7 @@ pub fn regex(input: TokenStream) -> TokenStream {
     let lit_str = syn::parse::<syn::LitStr>(input).unwrap();
     let regex_build = RegexCode::from(lit_str).build;
     let q = quote! {{
-        use lazy_regex::Lazy;
-        static RE: Lazy<regex::Regex> = #regex_build;
+        static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         &RE
     }};
     q.into()
@@ -160,8 +159,7 @@ pub fn regex_is_match(input: TokenStream) -> TokenStream {
     let regex_build = RegexCode::from(regex_and_expr_args.regex_str).build;
     let value = regex_and_expr_args.value;
     let q = quote! {{
-        use lazy_regex::Lazy;
-        static RE: Lazy<regex::Regex> = #regex_build;
+        static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         RE.is_match(#value)
     }};
     q.into()
@@ -182,8 +180,7 @@ pub fn regex_find(input: TokenStream) -> TokenStream {
     let regex_build = regex_code.build;
     let value = regex_and_expr_args.value;
     let q = quote! {{
-        use lazy_regex::Lazy;
-        static RE: Lazy<regex::Regex> = #regex_build;
+        static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         RE.find(#value).map(|mat| mat.as_str())
     }};
     q.into()
@@ -217,8 +214,7 @@ pub fn regex_captures(input: TokenStream) -> TokenStream {
             caps.get(#i).map_or("", |c| c.as_str())
         });
     let q = quote! {{
-        use lazy_regex::Lazy;
-        static RE: Lazy<regex::Regex> = #regex_build;
+        static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         RE.captures(#value)
             .map(|caps| (
                 #(#groups),*
@@ -257,11 +253,10 @@ pub fn regex_replace_all(input: TokenStream) -> TokenStream {
             caps.get(#i).map_or("", |c| c.as_str())
         });
     let q = quote! {{
-        use lazy_regex::Lazy;
-        static RE: Lazy<regex::Regex> = #regex_build;
+        static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         RE.replace_all(
             #value,
-            |caps: &regex::Captures<'_>| {
+            |caps: &lazy_regex::Captures<'_>| {
                 let fun = #fun;
                 fun(
                     #(#groups),*

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -3,16 +3,8 @@ use {
     proc_macro2,
     quote::quote,
     syn::{
-        Expr,
-        ExprClosure,
-        LitStr,
-        Token,
-        parse::{
-            Parse,
-            ParseStream,
-            Result,
-        },
-        parse_macro_input,
+        parse::{Parse, ParseStream, Result},
+        parse_macro_input, Expr, ExprClosure, LitStr, Token,
     },
 };
 
@@ -112,10 +104,7 @@ impl Parse for RegexAndExpr {
         input.parse::<Token![,]>()?;
         let value = input.parse::<Expr>()?;
         let _ = input.parse::<Token![,]>(); // allow a trailing comma
-        Ok(RegexAndExpr {
-            regex_str,
-            value,
-        })
+        Ok(RegexAndExpr { regex_str, value })
     }
 }
 
@@ -210,9 +199,11 @@ pub fn regex_captures(input: TokenStream) -> TokenStream {
     let regex_build = regex_code.build;
     let value = regex_and_expr_args.value;
     let n = regex_code.regex.captures_len();
-    let groups = (0..n).map(|i| quote! {
+    let groups = (0..n).map(|i| {
+        quote! {
             caps.get(#i).map_or("", |c| c.as_str())
-        });
+        }
+    });
     let q = quote! {{
         static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         RE.captures(#value)
@@ -249,9 +240,11 @@ pub fn regex_replace_all(input: TokenStream) -> TokenStream {
     let value = args.value;
     let fun = args.fun;
     let n = regex_code.regex.captures_len();
-    let groups = (0..n).map(|i| quote! {
+    let groups = (0..n).map(|i| {
+        quote! {
             caps.get(#i).map_or("", |c| c.as_str())
-        });
+        }
+    });
     let q = quote! {{
         static RE: lazy_regex::Lazy<lazy_regex::Regex> = #regex_build;
         RE.replace_all(


### PR DESCRIPTION
This removes the need for a peer dependency to the regex crate, just like you are already doing for once_cell.