### PR TITLE
Add regex::bytes::Regex support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@ Use the  [regex!] macro to build regexes:
 * they can hold flags as suffix: `let case_insensitive_regex = regex!("ab*"i);`
 * regex creation is less verbose
 
-This macro returns references to normal instances of [regex::Regex] so all the usual features are available.
+This macro returns references to normal instances of [regex::Regex] or [regex::bytes::Regex] so all the usual features are available.
+
+A special, non-standard flag, `B`, is used to indicate a `regex::bytes::Regex` variant,
+which operates on bytes (`&[u8]`) instead of `&str`s.
 
 You may also use shortcut macros for testing a match, replacing with concise closures, or capturing groups as substrings in some common situations:
 
@@ -16,6 +19,8 @@ You may also use shortcut macros for testing a match, replacing with concise clo
 * [regex_captures!]
 * [regex_replace!]
 * [regex_replace_all!]
+
+All of them support the `B` flag for the `regex::bytes::Regex` variant.
 
 Some structs of the regex crate are reexported to ease dependency managment.
 
@@ -39,6 +44,10 @@ assert_eq!(r.is_match("\"\""), true);
 // or a raw literal with flag(s)
 let r = regex!(r#"^\s*("[a-t]*"\s*)+$"#i);
 assert_eq!(r.is_match(r#" "Aristote" "Platon" "#), true);
+
+// build a regex that operates on &[u8]
+let r = regex!("(byte)?string$"B);
+assert_eq!(r.is_match(b"bytestring"), true);
 
 // there's no problem using the multiline definition syntax
 let r = regex!(r#"(?x)
@@ -76,6 +85,8 @@ use lazy_regex::regex_find;
 
 let f_word = regex_find!(r#"\bf\w+\b"#, "The fox jumps.");
 assert_eq!(f_word, Some("fox"));
+let f_word = regex_find!(r#"\bf\w+\b"#B, b"The forest is silent.");
+assert_eq!(f_word, Some(b"forest" as &[u8]));
 ```
 
 doc: [regex_find!]
@@ -150,7 +161,21 @@ pub use {
         regex_is_match,
         regex_replace,
         regex_replace_all,
+        /*/ bytes variants
+        lazy_regex_bytes, regex_bytes,
+        regex_captures_bytes,
+        regex_find_bytes,
+        regex_is_match_bytes,
+        regex_replace_bytes,
+        regex_replace_all_bytes,
+        */
     },
     once_cell::sync::Lazy,
-    regex::{Captures, Regex, RegexBuilder},
+    regex::{
+        Captures, Regex, RegexBuilder,
+        bytes::{
+            Regex as BytesRegex,
+            RegexBuilder as BytesRegexBuilder
+        },
+    },
 };

--- a/src/proc_macros/args.rs
+++ b/src/proc_macros/args.rs
@@ -1,8 +1,6 @@
-use {
-    syn::{
-        parse::{Parse, ParseStream, Result},
-        Expr, ExprClosure, LitStr, Token,
-    },
+use syn::{
+    parse::{Parse, ParseStream, Result},
+    Expr, ExprClosure, LitStr, Token,
 };
 
 /// Wrapping of the two arguments given to one of the
@@ -12,6 +10,7 @@ pub(crate) struct RexValArgs {
     pub regex_str: LitStr,
     pub value: Expr, // this expression is (or produces) the text to search or check
 }
+
 impl Parse for RexValArgs {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let regex_str = input.parse::<LitStr>()?;

--- a/src/proc_macros/regex_code.rs
+++ b/src/proc_macros/regex_code.rs
@@ -1,24 +1,51 @@
 use {
-    proc_macro2,
     quote::quote,
     syn::LitStr,
+    proc_macro::TokenStream,
+    proc_macro2::TokenStream as TokenStream2,
 };
+
+fn quote_build(pattern: &str, is_bytes: bool,
+        case_insensitive: bool, multi_line: bool,
+        dot_matches_new_line: bool, ignore_whitespace: bool,
+        swap_greed: bool) -> TokenStream2 {
+    let builder_token = if is_bytes {
+        quote! { BytesRegexBuilder }
+    } else {
+        quote! { RegexBuilder }
+    };
+    quote! {
+        lazy_regex::Lazy::new(|| {
+            //println!("compiling regex {:?}", #pattern);
+            lazy_regex:: #builder_token ::new(#pattern)
+                .case_insensitive(#case_insensitive)
+                .multi_line(#multi_line)
+                .dot_matches_new_line(#dot_matches_new_line)
+                .ignore_whitespace(#ignore_whitespace)
+                .swap_greed(#swap_greed)
+                .build().unwrap()
+        })
+    }
+}
 
 /// The lazy static regex building code, which is produced and
 /// inserted by all lazy-regex macros
 pub(crate) struct RegexCode {
-    pub regex: regex::Regex,
-    pub build: proc_macro2::TokenStream,
+    pub build: TokenStream2,
+    pub is_bytes: bool,
+    regex: Option<regex::Regex>,
+    regex_bytes: Option<regex::bytes::Regex>,
 }
 
 impl From<LitStr> for RegexCode {
     fn from(lit_str: LitStr) -> Self {
-        let regex_string = lit_str.value();
+        let pattern = lit_str.value();
         let mut case_insensitive = false;
         let mut multi_line = false;
         let mut dot_matches_new_line = false;
         let mut ignore_whitespace = false;
         let mut swap_greed = false;
+        let mut is_bytes = false;
         for ch in lit_str.suffix().chars() {
             match ch {
                 'i' => case_insensitive = true,
@@ -26,31 +53,79 @@ impl From<LitStr> for RegexCode {
                 's' => dot_matches_new_line = true,
                 'x' => ignore_whitespace = true,
                 'U' => swap_greed = true,
+                'B' => is_bytes = true, // non-standard!
                 _ => {
                     panic!("unrecognized regex flag {:?}", ch);
                 }
             };
         }
 
-        // the next line prevents compilation if the
-        // literal is invalid as a regular expression
-        let regex = regex::Regex::new(&regex_string).unwrap();
+        // also prevents compilation if the literal is invalid as
+        // a regular expression
+        let regex = if is_bytes {
+            None
+        } else {
+            Some(regex::Regex::new(&pattern).unwrap())
+        };
+        let regex_bytes = if is_bytes {
+            Some(regex::bytes::Regex::new(&pattern).unwrap())
+        } else {
+            None
+        };
 
-        let build = quote! {{
-            lazy_regex::Lazy::new(|| {
-                //println!("compiling regex {:?}", #regex_string);
-                let mut builder = lazy_regex::RegexBuilder::new(#regex_string);
-                builder.case_insensitive(#case_insensitive);
-                builder.multi_line(#multi_line);
-                builder.dot_matches_new_line(#dot_matches_new_line);
-                builder.ignore_whitespace(#ignore_whitespace);
-                builder.swap_greed(#swap_greed);
-                builder.build().unwrap()
-            })
-        }};
-
-        Self { regex, build }
+        let build = quote_build(&pattern, is_bytes,
+            case_insensitive, multi_line, dot_matches_new_line,
+            ignore_whitespace, swap_greed);
+        Self {
+            build,
+            is_bytes,
+            regex,
+            regex_bytes,
+        }
     }
 }
 
+impl From<TokenStream> for RegexCode {
+    fn from(token_stream: TokenStream) -> Self {
+        Self::from(syn::parse::<syn::LitStr>(token_stream).unwrap())
+    }
+}
+
+impl RegexCode {
+    pub fn regex(&self) -> &regex::Regex {
+        self.regex.as_ref().unwrap()
+    }
+
+    pub fn regex_bytes(&self) -> &regex::bytes::Regex {
+        self.regex_bytes.as_ref().unwrap()
+    }
+
+    pub fn statick(&self) -> TokenStream2 {
+        let build = &self.build;
+        let regex_token = if self.is_bytes {
+            quote! { BytesRegex }
+        } else {
+            quote! { Regex }
+        };
+        quote! {
+            static RE: lazy_regex::Lazy<lazy_regex:: #regex_token > = #build;
+        }
+    }
+
+    pub fn lazy_static(&self) -> TokenStream2 {
+        let statick = self.statick();
+        quote! {{
+            #statick;
+            &RE
+        }}
+    }
+
+    pub fn captures_len(&self) -> usize {
+        if self.is_bytes {
+            self.regex_bytes().captures_len()
+        } else {
+            self.regex().captures_len()
+        }
+    }
+}
 


### PR DESCRIPTION
This is a draft of #11 that works (passed `cargo check` & `cargo test`) but lacks docs, tests, review etc.

- Added `B` flag for `regex::bytes::Regex` variant
- Changed `RegexCode` to detect flag and build corresponding token stream at creation
- Added convenience methods to shorten macro implementations
- Split generation code into smaller pieces