### PR TITLE
Increase syn min version

### DIFF
--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0.22", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.5"


### PR DESCRIPTION
Building a project with cargo --minimal-versions will fail since `syn`'s version is too low.

Relevant release
https://github.com/dtolnay/syn/releases/tag/1.0.22