### PR TITLE
"lite" feature to use regex-lite instead of regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-### next (major)
+<a name="v3.0.0"></a>
+### v3.0.0 - 2023-07-07
 - the `lite` feature switches the engine to `regex-lite` instead of `regex`. The whole regex|regex-lite crate is reexported under `lazy_regex::regex`
+- regex crate upgraded to 1.9
 
 <a name="v2.5.0"></a>
 ### v2.5.0 - 2023-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next (major)
+- the `lite` feature switches the engine to `regex-lite` instead of `regex`. The whole regex|regex-lite crate is reexported under `lazy_regex::regex`
+
 <a name="v2.5.0"></a>
 ### v2.5.0 - 2023-03-09
 - `replace!` and `replace_all!` now supports non closure replacers - Fix #19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-regex"
-version = "2.5.0"
+version = "3.0.0"
 authors = ["Canop <cano.petrole@gmail.com>"]
 edition = "2021"
 description = "lazy static regular expressions checked at compile time"
@@ -13,15 +13,17 @@ rust-version = "1.56"
 
 [dependencies]
 once_cell = "1.17"
-regex = {version = "1.7", default_features = false, features = ["std"]}
+regex = {version = "1.9", default_features = false, features = ["std"], optional = true}
+regex-lite = {version = "0.1", optional = true}
 
 [dependencies.lazy-regex-proc_macros]
 path = "src/proc_macros"
-version = "2.4.0"
+version = "3.0.0"
 
 [features]
 default = ["regex/default"]
 std = ["regex/std"]
+lite = ["regex-lite"]
 perf = ["regex/perf"]
 perf-cache = ["regex/perf-cache"]
 perf-dfa = ["regex/perf-dfa"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Other macros are specialized for testing a match, replacing with concise closure
 All of them support the `B` flag for the `regex::bytes::Regex` variant.
 
 Some structs of the regex crate are reexported to ease dependency managment.
+The regex crate itself is also reexported, to avoid the need to synchronize the versions/flavor (see [Features](#features_and_reexport) below)
 
 # Build Regexes
 
@@ -171,4 +172,18 @@ pub static GLOBAL_REX: Lazy<Regex> = lazy_regex!("^ab+$"i);
 
 Like for the other macros, the regex is static, checked at compile time, and lazily built at first use.
 
+# Features and reexport
 
+With default features, `lazy-regex` use the `regex` crate with its default features, tailored for performances and complete Unicode support.
+
+You may enable a different set of regex features by directly enabling them when importing `lazy-regex`.
+
+It's also possible to use the [regex-lite](https://docs.rs/regex-lite/) crate instead of the [regex](https://docs.rs/regex/) crate by declaring the ``lite`` feature:
+
+```TOML
+lazy-regex = { version = "2.6.0", default-features = false, features = ["lite"] }
+```
+
+The `lite` flavor comes with slightly lower performances and a reduced Unicode support (see crate documentation) but also a much smaller binary size.
+
+If you need to refer to the regex crate in your code, prefer to use the reexport (i.e. `use lazy_regex::regex;`) so that you don't have a version or flavor conflict. When the `lite` feature is enabled, `lazy_regex::regex` refers to `regex_lite` so you don't have to change your code when switching regex engine.

--- a/bacon.toml
+++ b/bacon.toml
@@ -45,22 +45,5 @@ command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
-# You can run your application and have the result displayed in bacon,
-# *if* it makes sense for this crate. You can run an example the same
-# way. Don't forget the `--color always` part or the errors won't be
-# properly parsed.
-[jobs.run]
-command = [
-    "cargo", "run",
-    "--color", "always",
-    # put launch parameters for your program behind a `--` separator
-]
-need_stdout = true
-allow_warnings = true
-
-# You may define here keybindings that would be specific to
-# a project, for example a shortcut to launch a specific job.
-# Shortcuts to internal functions (scrolling, toggling, etc.)
-# should go in your personal global prefs.toml file instead.
 [keybindings]
 # alt-m = "job:my-job"

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,66 @@
+# This is a configuration file for the bacon tool
+#
+# Bacon repository: https://github.com/Canop/bacon
+# Complete help on configuration: https://dystroy.org/bacon/config/
+# You can also check bacon's own bacon.toml file
+#  as an example: https://github.com/Canop/bacon/blob/main/bacon.toml
+
+default_job = "check"
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+
+[jobs.lite]
+command = ["cargo", "check", "--all-targets", "--color", "always", "--no-default-features", "--features", "lite"]
+need_stdout = false
+
+[jobs.clippy]
+command = [
+    "cargo", "clippy",
+    "--all-targets",
+    "--color", "always",
+]
+need_stdout = false
+
+[jobs.test]
+command = [
+    "cargo", "test", "--color", "always",
+    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
+]
+need_stdout = true
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# If the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate. You can run an example the same
+# way. Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+[jobs.run]
+command = [
+    "cargo", "run",
+    "--color", "always",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal global prefs.toml file instead.
+[keybindings]
+# alt-m = "job:my-job"

--- a/examples/regexes/Cargo.toml
+++ b/examples/regexes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regexes"
-version = "1.0.1"
+version = "3.0.0"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 edition = "2018"
 description = "An example for lazy-regex"
@@ -9,4 +9,3 @@ readme = "README.md"
 
 [dependencies]
 lazy-regex = { path = "../.." }
-regex = "1.7"

--- a/examples/regexes/README.md
+++ b/examples/regexes/README.md
@@ -3,7 +3,7 @@ This example displays a few compilation regexes.
 
 To demonstrate compile time checks
 
-- uncomment line 24
+- uncomment line 23
 - run `cargo run`
 
 The program should fail to check with a clear error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,12 +176,25 @@ pub use {
         regex_replace_all,
     },
     once_cell::sync::Lazy,
+};
+
+#[cfg(not(feature = "lite"))]
+pub use {
     regex::{
+        self,
         Captures, Regex, RegexBuilder,
         bytes::{
             Regex as BytesRegex,
             RegexBuilder as BytesRegexBuilder
         },
+    },
+};
+
+#[cfg(feature = "lite")]
+pub use {
+    regex_lite::{
+        self as regex,
+        Captures, Regex, RegexBuilder,
     },
 };
 

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-regex-proc_macros"
-version = "2.4.1"
+version = "3.0.0"
 authors = ["Canop <cano.petrole@gmail.com>"]
 description = "proc macros for the lazy_regex crate"
 license = "MIT"
@@ -10,7 +10,7 @@ edition = "2018"
 syn = { version = "1.0.103", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
-regex = "1.7"
+regex = "1.9"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Enabling the "lite" feature:

     lazy-regex = { version = "2.6.0", default-features = false, features = ["lite"] }

This wins about 1.2MB on the final stripped binary size.