### PR TITLE
Update syn to 2.0

### DIFF
--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-syn = { version = "1.0.103", features = ["full"] }
+syn = { version = "2.0.27", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.9"


### PR DESCRIPTION
So I made an attempt at updating `syn`, and it turned out to be pretty effortless. All existing code appears to be compatible with v2, plus the MSRV is the same (Rust 1.56), so all that it took was a version change.

Resolves #23.