### PR TITLE
Add repository link

### DIFF
--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Canop <cano.petrole@gmail.com>"]
 description = "proc macros for the lazy_regex crate"
 license = "MIT"
 edition = "2018"
+repository = "https://github.com/Canop/lazy-regex/tree/main/src/proc_macros"
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }


### PR DESCRIPTION
This crate is missing a repository link here: https://crates.io/crates/lazy-regex-proc_macros