### PR TITLE
Use std::sync::LazyLock instead of once_cell::sync::Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 rust-version = "1.56"
 
 [dependencies]
-once_cell = "1.17"
 regex = {version = "1.9", default-features = false, optional = true}
 regex-lite = {version = "0.1", optional = true}
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 With lazy-regex macros, regular expressions
 
 * are checked at compile time, with clear error messages
-* are wrapped in `once_cell` lazy static initializers so that they're compiled only once
+* are wrapped in `std` lazy static initializers so that they're compiled only once
 * can hold flags as suffix: `let case_insensitive_regex = regex!("ab*"i);`
 * are defined in a less verbose way
 

--- a/examples/regexes/src/main.rs
+++ b/examples/regexes/src/main.rs
@@ -1,6 +1,6 @@
 use lazy_regex::*;
 
-pub static SHARED: Lazy<Regex> = lazy_regex!("^test$");
+pub static SHARED: LazyLock<Regex> = lazy_regex!("^test$");
 
 fn example_builds() {
     // build a simple regex

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 With lazy-regex macros, regular expressions
 
 * are checked at compile time, with clear error messages
-* are wrapped in `once_cell` lazy static initializers so that they're compiled only once
+* are wrapped in `std` lazy static initializers so that they're compiled only once
 * can hold flags as suffix: `let case_insensitive_regex = regex!("ab*"i);`
 * are defined in a less verbose way
 
@@ -195,7 +195,7 @@ If you want to have a shared lazy static regex, use the [lazy_regex!] macro:
 ```rust
 use lazy_regex::*;
 
-pub static GLOBAL_REX: Lazy<Regex> = lazy_regex!("^ab+$"i);
+pub static GLOBAL_REX: LazyLock<Regex> = lazy_regex!("^ab+$"i);
 ```
 
 Like for the other macros, the regex is static, checked at compile time, and lazily built at first use.
@@ -225,7 +225,7 @@ pub use {
         bytes_regex_replace_all,
         bytes_regex_switch,
     },
-    once_cell::sync::Lazy,
+    std::sync::LazyLock
 };
 
 #[cfg(not(feature = "lite"))]

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -67,14 +67,14 @@ pub fn bytes_regex(input: TokenStream) -> TokenStream {
     process(input, true, |regex_code| regex_code.lazy_static())
 }
 
-/// Return an instance of `once_cell::sync::Lazy<regex::Regex>` or
-/// `once_cell::sync::Lazy<regex::bytes::Regex>` that
+/// Return an instance of `LazyLock<regex::Regex>` or
+/// `LazyLock<regex::bytes::Regex>` that
 /// you can use in a public static declaration.
 ///
 /// Example:
 ///
 /// ```
-/// pub static GLOBAL_REX: Lazy<Regex> = lazy_regex!("^ab+$"i);
+/// pub static GLOBAL_REX: LazyLock<Regex> = lazy_regex!("^ab+$"i);
 /// ```
 ///
 /// As for other macros, the regex is checked at compilation time.
@@ -83,13 +83,13 @@ pub fn lazy_regex(input: TokenStream) -> TokenStream {
     process(input, false, |regex_code| regex_code.build)
 }
 
-/// Return an instance of `once_cell::sync::Lazy<bytes::Regex>` that
+/// Return an instance of `LazyLock<bytes::Regex>` that
 /// you can use in a public static declaration.
 ///
 /// Example:
 ///
 /// ```
-/// pub static GLOBAL_REX: Lazy<bytes::Regex> = bytes_lazy_regex!("^ab+$"i);
+/// pub static GLOBAL_REX: LazyLock<bytes::Regex> = bytes_lazy_regex!("^ab+$"i);
 /// ```
 ///
 /// As for other macros, the regex is checked at compilation time.

--- a/src/proc_macros/regex_code.rs
+++ b/src/proc_macros/regex_code.rs
@@ -61,7 +61,7 @@ impl RegexCode {
             quote!(RegexBuilder)
         };
         let build = quote! {
-            lazy_regex::Lazy::new(|| {
+            std::sync::LazyLock::new(|| {
                 //println!("compiling regex {:?}", #pattern);
                 lazy_regex:: #builder_token ::new(#pattern)
                     .case_insensitive(#case_insensitive)
@@ -85,7 +85,7 @@ impl RegexCode {
             RegexInstance::Bytes(..) => quote!(BytesRegex),
         };
         quote! {
-            static RE: lazy_regex::Lazy<lazy_regex:: #regex_token > = #build;
+            static RE: std::sync::LazyLock<lazy_regex:: #regex_token > = #build;
         }
     }
 


### PR DESCRIPTION
Replaced **once_cell::sync::Lazy** with **std::sync::LazyLock**. The standard library's LazyLock provides equivalent functionality and avoids the need for an external dependency.