### PR TITLE
regex_remove_all! and bytes_regex_remove_all!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+<a name="v3.5.1"></a>
+### v3.5.1 - 2026-01-04
+- `regex_remove!` and `bytes_regex_remove!`
+
 <a name="v3.4.1"></a>
 ### v3.4.1 - 2024-12-27
 - regex_captures_iter! macro - Fix #37

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-regex"
-version = "3.5.0"
+version = "3.5.1"
 authors = ["Canop <cano.petrole@gmail.com>"]
 edition = "2021"
 description = "lazy static regular expressions checked at compile time"
@@ -18,7 +18,7 @@ regex-lite = {version = "0.1", optional = true}
 
 [dependencies.lazy-regex-proc_macros]
 path = "src/proc_macros"
-version = "3.5.0"
+version = "3.5.1"
 
 [features]
 default = ["regex/default"]

--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ They're all case insensitive instances of `regex::bytes::Regex`.
 # Test a match
 
 ```rust
-use lazy_regex::*;
-
 let b = regex_is_match!("[ab]+", "car");
 assert_eq!(b, true);
 let b = bytes_regex_is_match!("[ab]+", b"car");
@@ -121,8 +119,6 @@ See [`regex_is_match!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex
 # Extract a value
 
 ```rust
-use lazy_regex::regex_find;
-
 let f_word = regex_find!(r"\bf\w+\b", "The fox jumps.");
 assert_eq!(f_word, Some("fox"));
 let f_word = regex_find!(r"\bf\w+\b"B, b"The forest is silent.");
@@ -134,8 +130,6 @@ See [`regex_find!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_fin
 # Capture
 
 ```rust
-use lazy_regex::regex_captures;
-
 let (_, letter) = regex_captures!("([a-z])[0-9]+"i, "form A42").unwrap();
 assert_eq!(letter, "A");
 
@@ -158,8 +152,6 @@ See [`regex_captures!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex
 # Iter on captures
 
 ```rust
-use lazy_regex::regex_captures_iter;
-
 let hay = "'Citizen Kane' (1941), 'The Wizard of Oz' (1939), 'M' (1931).";
 let mut movies = vec![];
 let iter = regex_captures_iter!(r"'([^']+)'\s+\(([0-9]{4})\)", hay);
@@ -182,8 +174,6 @@ The [`regex_replace!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_
 ## Replace with a closure
 
 ```rust
-use lazy_regex::regex_replace_all;
-
 let text = "Foo8 fuu3";
 let text = regex_replace_all!(
     r"\bf(\w+)(\d)"i,
@@ -199,7 +189,6 @@ If it doesn't match you get a clear error message at compilation time.
 ## Replace with another kind of Replacer
 
 ```rust
-use lazy_regex::regex_replace_all;
 let text = "UwU";
 let output = regex_replace_all!("U", text, "O");
 assert_eq!(&output, "OwO");
@@ -209,11 +198,9 @@ assert_eq!(&output, "OwO");
 
 [`regex_remove!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove.html) is cleaner than using `regex_replace!` with an empty string.
 
-Contrary to replace, it doesn't allocate a new string if the match is at an end of the input, which makes it especially useful for trimming suffixes or prefixes.
+Contrary to `replace`, lazy-regex removing macros don't allocate a new string if the match is at an end of the input, which makes it especially useful for trimming suffixes or prefixes.
 
 ```rust
-use lazy_regex::regex_remove;
-
 let text = "lazy-regex-3.5.0";
 let name = regex_remove!(
     r"-[0-9]+(\.[0-9]+)*$",
@@ -225,12 +212,17 @@ assert!(matches!(name, std::borrow::Cow::Borrowed(_)));
 
 You can also remove all matches of a regex with [`regex_remove_all!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove_all.html).
 
+```rust
+assert_eq!(
+    regex_remove_all!(r"\s+", "    ab  c    d  e    "),
+    "abcde"
+);
+```
+
 Whenever possible, no new string is allocated and a borrowed slice is returned, even when several matches are removed
 (if they're all either at the start or end of the text).
 
 ```rust
-use lazy_regex::regex_remove_all;
-
 let input = "154681string63731";
 let output = regex_remove_all!(r"\d", input);
 assert_eq!(output, "string");

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ But most often, you won't even use the `regex!` macro but the other macros which
 * [Capture](#capture) with [`regex_captures!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_captures.html)
 * [Iter on captures](#iter-on-captures) with [`regex_captures_iter!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_captures_iter.html)
 * [Replace with captured groups](#replace-with-captured-groups) with [`regex_replace!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_replace.html) and [`regex_replace_all!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_replace_all.html)
-* [Remove part of a string](#remove-part-of-a-string) with [`regex_remove!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove.html)
+* [Remove part(s) of a string](#remove-part-of-a-string) with [`regex_remove!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove.html) and [`regex_remove_all!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove_all.html)
 * [Switch over patterns](#switch-over-patterns) with [`regex_switch!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_switch.html)
 
 They support the `B` flag for the `regex::bytes::Regex` variant.
@@ -207,7 +207,7 @@ assert_eq!(&output, "OwO");
 
 # Remove part of a string
 
-`regex_remove!` is cleaner than using `regex_replace!` with an empty string.
+[`regex_remove!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove.html) is cleaner than using `regex_replace!` with an empty string.
 
 Contrary to replace, it doesn't allocate a new string if the match is at an end of the input, which makes it especially useful for trimming suffixes or prefixes.
 
@@ -221,6 +221,20 @@ let name = regex_remove!(
 );
 assert_eq!(name, "lazy-regex");
 assert!(matches!(name, std::borrow::Cow::Borrowed(_)));
+```
+
+You can also remove all matches of a regex with [`regex_remove_all!`](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_remove_all.html).
+
+Whenever possible, no new string is allocated and a borrowed slice is returned, even when several matches are removed
+(if they're all either at the start or end of the text).
+
+```rust
+use lazy_regex::regex_remove_all;
+
+let input = "154681string63731";
+let output = regex_remove_all!(r"\d", input);
+assert_eq!(output, "string");
+assert!(matches!(output, std::borrow::Cow::Borrowed("string")));
 ```
 
 # Switch over patterns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ But most often, you won't even use the `regex!` macro but the other macros which
 * [Capture](#capture) with [`regex_captures!`]
 * [Iter on captures](#iter-on-captures) with [`regex_captures_iter!`]
 * [Replace with captured groups](#replace-with-captured-groups) with [`regex_replace!`] and [`regex_replace_all!`]
-* [Remove part of a string](#remove-part-of-a-string) with [`regex_remove!`]
+* [Remove part(s) of a string](#remove-part-of-a-string) with [`regex_remove!`] and [`regex_remove_all!`]
 * [Switch over patterns](#switch-over-patterns) with [`regex_switch!`]
 
 They support the `B` flag for the `regex::bytes::Regex` variant.
@@ -196,7 +196,7 @@ assert_eq!(&output, "OwO");
 
 # Remove part of a string
 
-`regex_remove!` is cleaner than using `regex_replace!` with an empty string.
+[`regex_remove!`] is cleaner than using `regex_replace!` with an empty string.
 
 Contrary to replace, it doesn't allocate a new string if the match is at an end of the input, which makes it especially useful for trimming suffixes or prefixes.
 
@@ -210,6 +210,20 @@ let name = regex_remove!(
 );
 assert_eq!(name, "lazy-regex");
 assert!(matches!(name, std::borrow::Cow::Borrowed(_)));
+```
+
+You can also remove all matches of a regex with [`regex_remove_all!`].
+
+Whenever possible, no new string is allocated and a borrowed slice is returned, even when several matches are removed
+(if they're all either at the start or end of the text).
+
+```rust
+use lazy_regex::regex_remove_all;
+
+let input = "154681string63731";
+let output = regex_remove_all!(r"\d", input);
+assert_eq!(output, "string");
+assert!(matches!(output, std::borrow::Cow::Borrowed("string")));
 ```
 
 # Switch over patterns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,7 @@ They're all case insensitive instances of `regex::bytes::Regex`.
 # Test a match
 
 ```rust
-use lazy_regex::*;
-
+# use lazy_regex::*;
 let b = regex_is_match!("[ab]+", "car");
 assert_eq!(b, true);
 let b = bytes_regex_is_match!("[ab]+", b"car");
@@ -110,8 +109,7 @@ See [`regex_is_match!`]
 # Extract a value
 
 ```rust
-use lazy_regex::regex_find;
-
+# use lazy_regex::regex_find;
 let f_word = regex_find!(r"\bf\w+\b", "The fox jumps.");
 assert_eq!(f_word, Some("fox"));
 let f_word = regex_find!(r"\bf\w+\b"B, b"The forest is silent.");
@@ -123,8 +121,7 @@ See [`regex_find!`]
 # Capture
 
 ```rust
-use lazy_regex::regex_captures;
-
+# use lazy_regex::regex_captures;
 let (_, letter) = regex_captures!("([a-z])[0-9]+"i, "form A42").unwrap();
 assert_eq!(letter, "A");
 
@@ -147,8 +144,7 @@ See [`regex_captures!`]
 # Iter on captures
 
 ```rust
-use lazy_regex::regex_captures_iter;
-
+# use lazy_regex::regex_captures_iter;
 let hay = "'Citizen Kane' (1941), 'The Wizard of Oz' (1939), 'M' (1931).";
 let mut movies = vec![];
 let iter = regex_captures_iter!(r"'([^']+)'\s+\(([0-9]{4})\)", hay);
@@ -171,8 +167,7 @@ The [`regex_replace!`] and [`regex_replace_all!`] macros bring once compilation 
 ## Replace with a closure
 
 ```rust
-use lazy_regex::regex_replace_all;
-
+# use lazy_regex::regex_replace_all;
 let text = "Foo8 fuu3";
 let text = regex_replace_all!(
     r"\bf(\w+)(\d)"i,
@@ -188,7 +183,7 @@ If it doesn't match you get a clear error message at compilation time.
 ## Replace with another kind of Replacer
 
 ```rust
-use lazy_regex::regex_replace_all;
+# use lazy_regex::regex_replace_all;
 let text = "UwU";
 let output = regex_replace_all!("U", text, "O");
 assert_eq!(&output, "OwO");
@@ -198,11 +193,10 @@ assert_eq!(&output, "OwO");
 
 [`regex_remove!`] is cleaner than using `regex_replace!` with an empty string.
 
-Contrary to replace, it doesn't allocate a new string if the match is at an end of the input, which makes it especially useful for trimming suffixes or prefixes.
+Contrary to `replace`, lazy-regex removing macros don't allocate a new string if the match is at an end of the input, which makes it especially useful for trimming suffixes or prefixes.
 
 ```rust
-use lazy_regex::regex_remove;
-
+# use lazy_regex::regex_remove;
 let text = "lazy-regex-3.5.0";
 let name = regex_remove!(
     r"-[0-9]+(\.[0-9]+)*$",
@@ -214,12 +208,19 @@ assert!(matches!(name, std::borrow::Cow::Borrowed(_)));
 
 You can also remove all matches of a regex with [`regex_remove_all!`].
 
+```rust
+# use lazy_regex::regex_remove_all;
+assert_eq!(
+    regex_remove_all!(r"\s+", "    ab  c    d  e    "),
+    "abcde"
+);
+```
+
 Whenever possible, no new string is allocated and a borrowed slice is returned, even when several matches are removed
 (if they're all either at the start or end of the text).
 
 ```rust
-use lazy_regex::regex_remove_all;
-
+# use lazy_regex::regex_remove_all;
 let input = "154681string63731";
 let output = regex_remove_all!(r"\d", input);
 assert_eq!(output, "string");
@@ -334,6 +335,17 @@ pub use {
     },
 };
 
+/// Remove the first match of a regex from the text, returning a borrowed slice when possible
+///
+/// ```rust
+/// # use lazy_regex::regex_remove;
+/// let name = regex_remove!(
+///     r"-[0-9]+(\.[0-9]+)*$",
+///      "lazy-regex-3.5.2",
+/// );
+/// assert_eq!(name, "lazy-regex");
+/// assert!(matches!(name, std::borrow::Cow::Borrowed(_)));
+/// ```
 #[macro_export]
 macro_rules! regex_remove {
     ($rex:tt, $text:expr $(,)?) => {{
@@ -357,6 +369,26 @@ macro_rules! bytes_regex_remove {
     }};
 }
 
+/// Remove all matches of a regex from the text
+///
+/// ```rust
+/// # use lazy_regex::regex_remove_all;
+/// assert_eq!(
+///     regex_remove_all!(r"\s+", "    ab  c    d  e    "),
+///     "abcde"
+/// );
+/// ```
+///
+/// Whenever possible, no new string is allocated and a borrowed slice is returned, even when several matches are removed
+/// (if they're all either at the start or end of the text).
+///
+/// ```rust
+/// # use lazy_regex::regex_remove_all;
+/// let input = "154681string63731";
+/// let output = regex_remove_all!(r"\d", input);
+/// assert_eq!(output, "string");
+/// assert!(matches!(output, std::borrow::Cow::Borrowed("string")));
+/// ```
 #[macro_export]
 macro_rules! regex_remove_all {
     ($rex:tt, $text:expr $(,)?) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ pub use {
     once_cell::sync::Lazy,
     remove::{
         remove_match,
+        remove_all_matches,
     },
 };
 
@@ -307,6 +308,7 @@ pub use {
     },
     remove::{
         bytes_remove_match,
+        bytes_remove_all_matches,
     },
 };
 
@@ -335,6 +337,28 @@ macro_rules! bytes_regex_remove {
     ($rex:tt, $text:expr $(,)?) => {{
         let rex = $crate::bytes_regex!($rex);
         $crate::bytes_remove_match(
+            &rex,
+            $text,
+        )
+    }};
+}
+
+#[macro_export]
+macro_rules! regex_remove_all {
+    ($rex:tt, $text:expr $(,)?) => {{
+        let rex = $crate::regex!($rex);
+        $crate::remove_all_matches(
+            &rex,
+            $text,
+        )
+    }};
+}
+
+#[macro_export]
+macro_rules! bytes_regex_remove_all {
+    ($rex:tt, $text:expr $(,)?) => {{
+        let rex = $crate::bytes_regex!($rex);
+        $crate::bytes_remove_all_matches(
             &rex,
             $text,
         )

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-regex-proc_macros"
-version = "3.5.0"
+version = "3.5.1"
 authors = ["Canop <cano.petrole@gmail.com>"]
 description = "proc macros for the lazy_regex crate"
 license = "MIT"

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -6,7 +6,7 @@ use {
 /// Remove the first match of the regex from the text.
 ///
 /// If the removed match is at the start or end of the input,
-/// a borrowed slice is returned.
+/// no new String is allocated and a borrowed slice is returned.
 #[must_use]
 pub fn remove_match<'s>(
     rex: &regex::Regex,
@@ -50,5 +50,140 @@ pub fn bytes_remove_match<'s>(
     s.extend_from_slice(&text[..m.start()]);
     s.extend_from_slice(&text[m.end()..]);
     Cow::Owned(s)
+}
+
+/// Remove all matches of the regex from the text.
+///
+/// When all matches are at the start or end of the input, no new
+/// String is allocated and a borrowed slice is returned.
+#[must_use]
+pub fn remove_all_matches<'s>(
+    rex: &regex::Regex,
+    text: &'s str,
+) -> Cow<'s, str> {
+    let mut trim_start_end = 0;
+    let mut it = rex.find_iter(text);
+    loop {
+        let Some(mut m) = it.next() else {
+            break;
+        };
+        if m.start() == trim_start_end {
+            // Match at the start of the remaining text
+            // (all matches so far are at the start of the input),
+            // we can just move the start of the slice forward
+            trim_start_end = m.end();
+            continue;
+        }
+        let rem_start = m.start();
+        // Match isn't at the start of the text, so either we have a hole, or all other
+        // matches are at the end of the input.
+        let mut hole_end = m.end();
+        loop {
+            if hole_end == text.len() {
+                // All matches are either at the start or end of the input, we
+                // can just return a borrowed slice
+                return Cow::Borrowed(&text[trim_start_end..rem_start]);
+            }
+            if let Some(nm) = it.next() {
+                if nm.start() != m.end() {
+                    // We have at least 2 slices to keep, so we need to create a new string
+                    let mut string = String::with_capacity(text.len() - trim_start_end);
+                    string.push_str(&text[trim_start_end..rem_start]);
+                    string.push_str(&text[m.end()..nm.start()]);
+                    // now we'll go till the end, adding the slices we keep
+                    let mut last_end = nm.end();
+                    loop {
+                        let Some(m) = it.next() else {
+                            string.push_str(&text[last_end..]);
+                            return Cow::Owned(string);
+                        };
+                        string.push_str(&text[last_end..m.start()]);
+                        last_end = m.end();
+                    }
+                }
+                // Next match is immediately after the current match, so we can skip it
+                hole_end = nm.end();
+                m = nm;
+            } else {
+                // There's no more matches, and we're not at the end of the input, so we need to
+                // create a new string because there's a hole in the middle of the input
+                dbg!(trim_start_end, rem_start, m.end(), text.len());
+                let len = (rem_start - trim_start_end) + (text.len() - m.end());
+                let mut string = String::with_capacity(len);
+                string.push_str(&text[trim_start_end..rem_start]);
+                string.push_str(&text[m.end()..]);
+                return Cow::Owned(string);
+            }
+        }
+    }
+    Cow::Borrowed(&text[trim_start_end..])
+}
+
+
+/// Remove all matches of the regex from the text.
+///
+/// When all matches are at the start or end of the input, no new
+/// String is allocated and a borrowed slice is returned.
+#[must_use]
+pub fn bytes_remove_all_matches<'s>(
+    rex: &regex::bytes::Regex,
+    text: &'s [u8],
+) -> Cow<'s, [u8]> {
+    let mut trim_start_end = 0;
+    let mut it = rex.find_iter(text);
+    loop {
+        let Some(mut m) = it.next() else {
+            break;
+        };
+        if m.start() == trim_start_end {
+            // Match at the start of the remaining text
+            // (all matches so far are at the start of the input),
+            // we can just move the start of the slice forward
+            trim_start_end = m.end();
+            continue;
+        }
+        let rem_start = m.start();
+        // Match isn't at the start of the text, so either we have a hole, or all other
+        // matches are at the end of the input.
+        let mut hole_end = m.end();
+        loop {
+            if hole_end == text.len() {
+                // All matches are either at the start or end of the input, we
+                // can just return a borrowed slice
+                return Cow::Borrowed(&text[trim_start_end..rem_start]);
+            }
+            if let Some(nm) = it.next() {
+                if nm.start() != m.end() {
+                    // We have at least 2 slices to keep, so we need to create a new string
+                    let mut string = Vec::with_capacity(text.len() - trim_start_end);
+                    string.extend_from_slice(&text[trim_start_end..rem_start]);
+                    string.extend_from_slice(&text[m.end()..nm.start()]);
+                    // now we'll go till the end, adding the slices we keep
+                    let mut last_end = nm.end();
+                    loop {
+                        let Some(m) = it.next() else {
+                            string.extend_from_slice(&text[last_end..]);
+                            return Cow::Owned(string);
+                        };
+                        string.extend_from_slice(&text[last_end..m.start()]);
+                        last_end = m.end();
+                    }
+                }
+                // Next match is immediately after the current match, so we can skip it
+                hole_end = nm.end();
+                m = nm;
+            } else {
+                // There's no more matches, and we're not at the end of the input, so we need to
+                // create a new string because there's a hole in the middle of the input
+                dbg!(trim_start_end, rem_start, m.end(), text.len());
+                let len = (rem_start - trim_start_end) + (text.len() - m.end());
+                let mut string = Vec::with_capacity(len);
+                string.extend_from_slice(&text[trim_start_end..rem_start]);
+                string.extend_from_slice(&text[m.end()..]);
+                return Cow::Owned(string);
+            }
+        }
+    }
+    Cow::Borrowed(&text[trim_start_end..])
 }
 

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -32,3 +32,65 @@ fn test_bytes_regex_remove() {
     assert_eq!(&output[..], b"string");
     assert!(matches!(output, std::borrow::Cow::Borrowed(b"string")));
 }
+
+#[test]
+fn test_regex_remove_all() {
+    let input = "154681string63731";
+
+    // no match: borrowed and unchanged
+    let output = regex_remove_all!("[A-Z]+", input);
+    assert!(matches!(output, std::borrow::Cow::Borrowed("154681string63731")));
+
+    // removing in the middle (a new string is created)
+    let output = regex_remove_all!("[a-z]+", input);
+    assert_eq!(output, "15468163731");
+
+    // removing one hole in the middle, in several matches (a new string is created)
+    let output = regex_remove_all!("[a-z]{2}", input);
+    assert_eq!(output, "15468163731");
+
+    // removing on ends (one match each side), no new string is created
+    let output = regex_remove_all!(r"\d+", input);
+    assert_eq!(output, "string");
+    assert!(matches!(output, std::borrow::Cow::Borrowed("string")));
+
+    // removing on start, no new string is created
+    let output = regex_remove_all!(r"^\d+", input);
+    assert_eq!(output, "string63731");
+    assert!(matches!(output, std::borrow::Cow::Borrowed("string63731")));
+
+    // removing on end, no new string is created
+    let output = regex_remove_all!(r"\d+$", input);
+    assert_eq!(output, "154681string");
+    assert!(matches!(output, std::borrow::Cow::Borrowed("154681string")));
+
+    // removing on ends (several matches each side), no new string is created
+    let output = regex_remove_all!(r"\d", input);
+    assert_eq!(output, "string");
+    assert!(matches!(output, std::borrow::Cow::Borrowed("string")));
+
+    // a few hard cases with various holes
+    assert_eq!(
+        regex_remove_all!(r"\d", "a1b2c3d4e5"),
+        "abcde"
+    );
+    assert_eq!(
+        regex_remove_all!(r"[a-z]", "a1b2c3d4e5"),
+        "12345"
+    );
+    assert_eq!(
+        regex_remove_all!(r"\d", "a11b22c33d44e55"),
+        "abcde"
+    );
+}
+
+#[test]
+#[cfg(not(feature = "lite"))]
+fn test_bytes_regex_remove_all() {
+    let input = b"154681string63731";
+
+    // removing on ends (several matches each side), no new vec is created
+    let output = bytes_regex_remove_all!(r"\d", input);
+    assert_eq!(&output[..], b"string");
+    assert!(matches!(output, std::borrow::Cow::Borrowed(b"string")));
+}

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -79,7 +79,11 @@ fn test_regex_remove_all() {
         "12345"
     );
     assert_eq!(
-        regex_remove_all!(r"\d", "a11b22c33d44e55"),
+        regex_remove_all!(r"\d", "a11b22c33333d44e55"),
+        "abcde"
+    );
+    assert_eq!(
+        regex_remove_all!(r"\s+", "    ab  c    d  e    "),
         "abcde"
     );
 }
@@ -93,4 +97,10 @@ fn test_bytes_regex_remove_all() {
     let output = bytes_regex_remove_all!(r"\d", input);
     assert_eq!(&output[..], b"string");
     assert!(matches!(output, std::borrow::Cow::Borrowed(b"string")));
+
+    // removing several matches
+    assert_eq!(
+        *bytes_regex_remove_all!(r"\s+", b"    ab  c    d  e    "),
+        *b"abcde"
+    );
 }


### PR DESCRIPTION
Those macros improve ergonomics of removing parts of strings but also avoid allocation when possible (i.e. when all the matches are either at the start or end of the string and what's kept is in only one piece).

    let input = "154681string63731";
    let output = regex_remove_all!(r"\d", input);
    assert_eq!(output, "string");
    assert!(matches!(output, std::borrow::Cow::Borrowed("string")));

Fix #45